### PR TITLE
fix: BVM_ETH deposit gas parity on revm-19 (cold reset + cross-tx original re-baseline)

### DIFF
--- a/crates/op-revm/src/api/exec.rs
+++ b/crates/op-revm/src/api/exec.rs
@@ -1,7 +1,7 @@
 //! Implementation of the [`ExecuteEvm`] trait for the [`OpEvm`].
 use crate::{
-    evm::OpEvm, handler::OpHandler, transaction::OpTxTr, L1BlockInfo, OpHaltReason, OpSpecId,
-    OpTransactionError,
+    evm::OpEvm, handler::OpHandler, transaction::bvm_eth::JournalColdExt, transaction::OpTxTr,
+    L1BlockInfo, OpHaltReason, OpSpecId, OpTransactionError,
 };
 use revm::{
     context::{result::ExecResultAndState, ContextSetters},
@@ -25,7 +25,7 @@ use revm::{
 /// Type alias for Optimism context
 pub trait OpContextTr:
     ContextTr<
-    Journal: JournalTr<State = EvmState>,
+    Journal: JournalTr<State = EvmState> + JournalColdExt,
     Tx: OpTxTr,
     Cfg: Cfg<Spec = OpSpecId>,
     Chain = L1BlockInfo,
@@ -35,7 +35,7 @@ pub trait OpContextTr:
 
 impl<T> OpContextTr for T where
     T: ContextTr<
-        Journal: JournalTr<State = EvmState>,
+        Journal: JournalTr<State = EvmState> + JournalColdExt,
         Tx: OpTxTr,
         Cfg: Cfg<Spec = OpSpecId>,
         Chain = L1BlockInfo,

--- a/crates/op-revm/src/constants.rs
+++ b/crates/op-revm/src/constants.rs
@@ -73,18 +73,4 @@ pub const L1_BLOCK_CONTRACT: Address = address!("0x42000000000000000000000000000
 pub const GAS_ORACLE_CONTRACT: Address = address!("420000000000000000000000000000000000000F");
 
 /// The address of the sequencer fee wallet, which is block coinbase.
-pub const SEQUENCER_FEE_VAULT_ADDRESS: Address =
-    address!("4200000000000000000000000000000000000011");
-
-/// Gas compensation for BVM_ETH mint operations to align with go-ethereum behavior.
-///
-/// This constant compensates for the gas calculation difference between REVM and go-ethereum
-/// when handling BVM_ETH state operations. The value of 4500 is derived from EIP-2929 access
-/// list gas costs:
-/// - Account access difference: 2500 (cold: 2600, warm: 100)
-/// - Storage slot access difference: 2000 (cold: 2100, warm: 100)
-///
-/// REVM marks BVM_ETH account and storage slots as warm during mint/transfer operations,
-/// while go-ethereum keeps them cold. When subsequent EVM execution accesses BVM_ETH,
-/// this compensation ensures consistent gas consumption.
-pub const BVM_ETH_MINT_GAS_COMPENSATION: u64 = 4500;
+pub const SEQUENCER_FEE_VAULT_ADDRESS: Address = address!("4200000000000000000000000000000000000011");

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -2,10 +2,11 @@
 use crate::{
     api::exec::OpContextTr,
     constants::{
-        BASE_FEE_RECIPIENT, BVM_ETH_MINT_GAS_COMPENSATION, GAS_ORACLE_CONTRACT, L1_FEE_RECIPIENT,
-        OPERATOR_FEE_RECIPIENT,
+        BASE_FEE_RECIPIENT, GAS_ORACLE_CONTRACT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT,
     },
-    transaction::{deposit::DEPOSIT_TRANSACTION_TYPE, OpTransactionError, OpTxTr},
+    transaction::{
+        bvm_eth::JournalColdExt, deposit::DEPOSIT_TRANSACTION_TYPE, OpTransactionError, OpTxTr,
+    },
     BvmEth, L1BlockInfo, OpHaltReason, OpSpecId,
 };
 use revm::{
@@ -83,6 +84,7 @@ impl<DB, TX> IsTxError for EVMError<DB, TX> {
 impl<EVM, ERROR, FRAME> Handler for OpHandler<EVM, ERROR, FRAME>
 where
     EVM: EvmTr<Context: OpContextTr, Frame = FRAME>,
+    <<EVM as EvmTr>::Context as ContextTr>::Journal: JournalColdExt,
     ERROR: EvmTrError<EVM> + From<OpTransactionError> + FromStringError + IsTxError,
     // TODO `FrameResult` should be a generic trait.
     // TODO `FrameInit` should be a generic.
@@ -186,6 +188,9 @@ where
 
         if is_deposit {
             // Process ETH deposit by minting and transferring BVM_ETH tokens.
+            // process_eth_deposit resets BVM_ETH (account + touched storage slots) back to
+            // cold afterwards, so subsequent EVM execution observes it as cold — matching
+            // op-geth's StateDB.SetState() mint which never touches the EVM access list.
             BvmEth::process_eth_deposit(ctx, false).map_err(ERROR::from)?;
         }
 
@@ -433,20 +438,10 @@ where
         let gas = frame_result.gas_mut();
         let is_system = tx.is_system_transaction();
 
-        // Apply gas compensation when BVM_ETH was warmed by pre-EVM mint/transfer and
-        // EVM code will execute. REVM's journal-based mint/transfer warms BVM_ETH account
-        // and storage slots, while op-geth's st.state.SetState() does not affect the EVM
-        // access list. When subsequent EVM execution touches BVM_ETH — either by a direct
-        // call or an internal call through the bridge — the warm/cold access cost
-        // difference (2500 account + 2000 storage = 4500) needs compensation.
-        // The condition guards against false positives: without eth_value/eth_tx_value no
-        // BVM_ETH warming occurs, and without input no contract code executes.
-        if (tx.eth_value().is_some() || tx.eth_tx_value().is_some()) && !tx.input().is_empty() {
-            gas.set_remaining(
-                gas.remaining()
-                    .saturating_sub(BVM_ETH_MINT_GAS_COMPENSATION),
-            );
-        }
+        // BVM_ETH warm/cold is reset to cold inside process_eth_deposit (see JournalColdExt),
+        // so subsequent EVM execution observes it cold exactly like op-geth. No static gas
+        // compensation is needed here (the previous mint-gas-compensation hack was removed —
+        // it over/under-compensated depending on the EVM access path).
 
         let limit = gas.limit();
         // Keep behavior aligned with op-geth: Uint256 token ratio is truncated to low 64 bits.
@@ -2958,384 +2953,6 @@ mod tests {
         assert_eq!(
             l1_cost_with_new_ratio, expected_l1_cost,
             "L1 cost should be calculated with NEW_TOKEN_RATIO (3040)"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_applied() {
-        let eth_value = 1_000_000_000_000_000_000u128; // 1 ETH
-        let initial_gas = 10000u64;
-        let remaining_gas = 5000u64;
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .data(Bytes::from(vec![0x12, 0x34])), // Non-empty input
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = Some(eth_value);
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-
-        // Gas compensation (4500) should be subtracted from remaining gas
-        // Since remaining_gas (5000) > BVM_ETH_MINT_GAS_COMPENSATION (4500),
-        // remaining should be 5000 - 4500 = 500
-        assert_eq!(
-            gas.remaining(),
-            remaining_gas - BVM_ETH_MINT_GAS_COMPENSATION,
-            "Gas compensation should be applied when eth_value exists and input is not empty"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_value_is_4500() {
-        // This verifies the constant matches the documented calculation:
-        // Account access difference: 2500 (cold: 2600, warm: 100)
-        // Storage slot access difference: 2000 (cold: 2100, warm: 100)
-        // Total: 2500 + 2000 = 4500
-        let eth_value = 1_000_000_000_000_000_000u128; // 1 ETH
-        let initial_gas = 10000u64;
-        let remaining_gas = 10000u64; // Use larger value to avoid saturation
-
-        // Test with compensation applied (eth_value exists and input is not empty)
-        // Note: Compensation also applies when eth_tx_value exists (tested separately)
-        let ctx_with_compensation = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .data(Bytes::from(vec![0x12, 0x34])), // Non-empty input
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = Some(eth_value);
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        // Test without compensation (no eth_value)
-        let ctx_without_compensation = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .data(Bytes::from(vec![0x12, 0x34])), // Non-empty input
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-        // eth_value is None by default, so compensation should not be applied
-
-        let gas_with_compensation = call_last_frame_return(
-            ctx_with_compensation,
-            InstructionResult::Stop,
-            Gas::new(remaining_gas),
-        );
-        let gas_without_compensation = call_last_frame_return(
-            ctx_without_compensation,
-            InstructionResult::Stop,
-            Gas::new(remaining_gas),
-        );
-
-        // Calculate the difference in remaining gas
-        let gas_difference =
-            gas_without_compensation.remaining() - gas_with_compensation.remaining();
-
-        // Verify the difference is exactly 4500
-        assert_eq!(
-            gas_difference, BVM_ETH_MINT_GAS_COMPENSATION,
-            "Gas compensation should be exactly {} (account diff 2500 + storage diff 2000)",
-            BVM_ETH_MINT_GAS_COMPENSATION
-        );
-        assert_eq!(
-            BVM_ETH_MINT_GAS_COMPENSATION, 4500,
-            "BVM_ETH_MINT_GAS_COMPENSATION constant should be 4500"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_not_applied_empty_input() {
-        let eth_value = 1_000_000_000_000_000_000u128; // 1 ETH
-        let initial_gas = 10000u64;
-        let remaining_gas = 5000u64;
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder().gas_limit(initial_gas).data(Bytes::new()), // Empty input
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = Some(eth_value);
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-
-        // Gas compensation should NOT be applied when input is empty
-        assert_eq!(
-            gas.remaining(),
-            remaining_gas,
-            "Gas compensation should NOT be applied when input is empty"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_not_applied_no_eth_value() {
-        let initial_gas = 10000u64;
-        let remaining_gas = 5000u64;
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .data(Bytes::from(vec![0x12, 0x34])), // Non-empty input
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-        // eth_value and eth_tx_value are None by default
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-
-        // Gas compensation should NOT be applied when both eth_value and eth_tx_value are None
-        assert_eq!(
-            gas.remaining(),
-            remaining_gas,
-            "Gas compensation should NOT be applied when both eth_value and eth_tx_value are None"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_saturating_sub() {
-        let eth_value = 1_000_000_000_000_000_000u128; // 1 ETH
-        let initial_gas = 10000u64;
-        let remaining_gas = 3000u64; // Less than BVM_ETH_MINT_GAS_COMPENSATION (4500)
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .data(Bytes::from(vec![0x12, 0x34])), // Non-empty input
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = Some(eth_value);
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-
-        // Gas compensation should use saturating_sub, so remaining should be 0 (not negative)
-        assert_eq!(
-            gas.remaining(),
-            0,
-            "Gas compensation should use saturating_sub when remaining gas is less than compensation"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_zero_eth_value() {
-        let initial_gas = 10000u64;
-        let remaining_gas = 5000u64;
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .data(Bytes::from(vec![0x12, 0x34])), // Non-empty input
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = Some(0); // Zero eth_value should be filtered out
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-
-        // Gas compensation should NOT be applied when eth_value is zero (returns None)
-        assert_eq!(
-            gas.remaining(),
-            remaining_gas,
-            "Gas compensation should NOT be applied when eth_value is zero"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_only_eth_tx_value() {
-        // Test that gas compensation is also applied when only eth_tx_value exists
-        // According to state.go, transferBVMETH also accesses BVM_ETH storage and would warm
-        // the account in REVM, so compensation is needed.
-        //
-        // Note: This test only verifies the compensation logic in refund(), not the actual
-        // transfer execution. The compensation check looks at eth_value() or eth_tx_value() and input(),
-        // so it doesn't matter if the transfer would succeed or fail.
-        let eth_tx_value = 500_000_000_000_000_000u128; // 0.5 ETH
-        let initial_gas = 10000u64;
-        let remaining_gas = 5000u64;
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .data(Bytes::from(vec![0x12, 0x34])), // Non-empty input
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = None;
-                tx.deposit.eth_tx_value = Some(eth_tx_value);
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-
-        // Gas compensation (4500) should be subtracted from remaining gas
-        // Since remaining_gas (5000) > BVM_ETH_MINT_GAS_COMPENSATION (4500),
-        // remaining should be 5000 - 4500 = 500
-        assert_eq!(
-            gas.remaining(),
-            remaining_gas - BVM_ETH_MINT_GAS_COMPENSATION,
-            "Gas compensation should be applied when only eth_tx_value exists and input is not empty"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_applied_bridge_target() {
-        // Gas compensation must also apply when tx targets the bridge (or any contract),
-        // because the bridge internally accesses BVM_ETH. The pre-EVM mint/transfer warms
-        // BVM_ETH in REVM but not in op-geth, so the compensation is needed regardless
-        // of whether the direct target is BVM_ETH.
-        let eth_value = 1_000_000_000_000_000_000u128; // 1 ETH
-        let initial_gas = 10000u64;
-        let remaining_gas = 5000u64;
-        // L2StandardBridge address
-        let bridge = Address::from([0x42; 20]);
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .kind(revm::primitives::TxKind::Call(bridge))
-                            .data(Bytes::from(vec![0x12, 0x34])),
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = Some(eth_value);
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-        assert_eq!(
-            gas.remaining(),
-            remaining_gas - BVM_ETH_MINT_GAS_COMPENSATION,
-            "Gas compensation should be applied even when target is not BVM_ETH (e.g., bridge)"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_real_l2_standard_bridge() {
-        // Real L2StandardBridge address used by Mantle deposit transactions.
-        // Deposits with eth_value routed through the bridge internally access
-        // BVM_ETH, so gas compensation must apply.
-        let eth_value = 1_000_000_000_000_000_000u128; // 1 ETH
-        let initial_gas = 10000u64;
-        let remaining_gas = 5000u64;
-        let l2_standard_bridge =
-            Address::from_str("0x4200000000000000000000000000000000000007").unwrap();
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .kind(revm::primitives::TxKind::Call(l2_standard_bridge))
-                            .data(Bytes::from(vec![0xd7, 0x64, 0xad, 0x0b])), // finalizeDeposit selector
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = Some(eth_value);
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-        assert_eq!(
-            gas.remaining(),
-            remaining_gas - BVM_ETH_MINT_GAS_COMPENSATION,
-            "Gas compensation must apply for L2StandardBridge deposits with eth_value"
-        );
-    }
-
-    #[test]
-    fn test_bvm_eth_gas_compensation_deposit_to_arbitrary_contract() {
-        // Edge case: deposit with eth_value targeting an arbitrary contract
-        // that may not touch BVM_ETH. Compensation still applies because:
-        // 1. Deposit txs are constructed by L1 system, not arbitrary user input
-        // 2. gasPrice=0 for deposits, so over-reporting 4500 gas is negligible
-        // 3. Restricting to specific targets broke real block gas alignment
-        let eth_value = 500_000_000u128;
-        let initial_gas = 10000u64;
-        let remaining_gas = 5000u64;
-        let arbitrary_contract = Address::from([0xAB; 20]);
-
-        let ctx = Context::op()
-            .with_tx(
-                OpTransaction::builder()
-                    .base(
-                        TxEnv::builder()
-                            .gas_limit(initial_gas)
-                            .kind(revm::primitives::TxKind::Call(arbitrary_contract))
-                            .data(Bytes::from(vec![0xCA, 0xFE])),
-                    )
-                    .source_hash(B256::from([1u8; 32]))
-                    .build_fill(),
-            )
-            .modify_tx_chained(|tx| {
-                tx.deposit.eth_value = Some(eth_value);
-            })
-            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS);
-
-        let gas = call_last_frame_return(ctx, InstructionResult::Stop, Gas::new(remaining_gas));
-        assert_eq!(
-            gas.remaining(),
-            remaining_gas - BVM_ETH_MINT_GAS_COMPENSATION,
-            "Gas compensation applies to all deposits with eth_value and input, regardless of target"
         );
     }
 

--- a/crates/op-revm/src/transaction/bvm_eth.rs
+++ b/crates/op-revm/src/transaction/bvm_eth.rs
@@ -9,12 +9,37 @@ use crate::transaction::{
 };
 use alloy_sol_types::SolValue;
 use revm::{
-    context::{JournalTr, Transaction},
+    context::{ContextTr, JournalTr, Transaction},
     primitives::{
         address, fixed_bytes, keccak256, Address, Bytes, FixedBytes, Log, LogData, TxKind, U256,
     },
+    Database, Journal,
 };
 use std::vec;
+
+/// Extension on the concrete [`Journal`] to reset an address (and its currently-loaded
+/// storage slots) back to EIP-2929 *cold*.
+///
+/// Used right after the BVM_ETH mint/transfer in [`BvmEth::process_eth_deposit`] so that
+/// subsequent EVM execution observes BVM_ETH as cold — exactly like op-geth, whose
+/// `StateDB.SetState()`-based mint never touches the EVM access list. Resetting the warm
+/// flags does NOT affect the persisted balance/totalSupply changes (those are journaled
+/// separately and stay committed); it only restores the EIP-2929 warm/cold accounting.
+pub trait JournalColdExt {
+    /// Mark `address` and all of its currently-loaded storage slots cold.
+    fn mark_address_cold(&mut self, address: Address);
+}
+
+impl<DB: Database> JournalColdExt for Journal<DB> {
+    fn mark_address_cold(&mut self, address: Address) {
+        if let Some(account) = self.inner.state().get_mut(&address) {
+            account.mark_cold();
+            for slot in account.storage.values_mut() {
+                slot.mark_cold();
+            }
+        }
+    }
+}
 
 /// BVM_ETH ERC20 token implementation.
 ///
@@ -89,6 +114,7 @@ impl BvmEth {
     ) -> Result<(), OpTransactionError>
     where
         CTX: OpContextTr,
+        <CTX as ContextTr>::Journal: JournalColdExt,
     {
         let (_, tx, _, journal, _, _) = context.all_mut();
 
@@ -120,6 +146,11 @@ impl BvmEth {
         }
 
         journal.touch_account(Self::ADDRESS);
+
+        // Reset BVM_ETH (account + the storage slots just touched by mint/transfer) back to
+        // cold so the subsequent EVM execution observes it cold, matching op-geth. This is the
+        // single source of warm/cold parity with op-geth — no static gas compensation anywhere.
+        journal.mark_address_cold(Self::ADDRESS);
         Ok(())
     }
 
@@ -571,6 +602,351 @@ mod tests {
     }
 
     /// Test case data structure
+    #[test]
+    fn process_eth_deposit_leaves_bvm_eth_cold() {
+        // After minting/transferring BVM_ETH, the account AND its touched storage slots must
+        // be COLD for the subsequent EVM execution — matching op-geth, whose SetState-based
+        // mint never warms the EVM access list. This is what makes the static gas
+        // compensation unnecessary.
+        let caller = Address::from([0x11; 20]);
+        let eth_value = 1_000_000_000_000_000u128; // 0.001 ETH
+
+        let mut ctx = Context::op()
+            .with_db(InMemoryDB::default())
+            .modify_tx_chained(|tx| {
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Call(caller); // to = EOA, deliberately NOT BVM_ETH
+                tx.deposit.source_hash = B256::from([1u8; 32]);
+                tx.deposit.eth_value = Some(eth_value);
+                tx.deposit.eth_tx_value = Some(eth_value);
+            });
+
+        BvmEth::process_eth_deposit(&mut ctx, false).expect("deposit processing should succeed");
+
+        // First post-mint access of the BVM_ETH account must report cold.
+        let acc = ctx
+            .journaled_state
+            .load_account(BvmEth::ADDRESS)
+            .expect("load BVM_ETH account");
+        assert!(
+            acc.is_cold,
+            "BVM_ETH account must be cold after process_eth_deposit"
+        );
+
+        // The caller's BVM_ETH balance slot (touched by mint + transfer) must also be cold.
+        let slot = BvmEth::get_balance_slot(caller);
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot)
+            .expect("sload BVM_ETH balance slot");
+        assert!(
+            loaded.is_cold,
+            "BVM_ETH balance slot must be cold after process_eth_deposit"
+        );
+    }
+
+    #[test]
+    fn deposit_to_eoa_with_calldata_no_compensation_matches_geth() {
+        // Deterministic replay of hoodi-qa2 block 59294 user deposit (the fork tx):
+        //   to = caller (EOA, no code), value = 0, input = 0xdeadbeef01020304 (8 nonzero bytes),
+        //   ethValue = ethTxValue = 0.001 ETH.
+        // op-geth gasUsed = 21320 (= 21000 + EIP-7623 floor for 8 calldata tokens, 32*10).
+        // The removed BVM_ETH_MINT_GAS_COMPENSATION (4500) previously inflated reth to 25628,
+        // diverging from op-geth and forking the chain at this block.
+        let caller = Address::from([0x74; 20]);
+        let eth_value = 1_000_000_000_000_000u128; // 0.001 ETH
+
+        let op_tx = OpTransaction {
+            base: TxEnv {
+                caller,
+                kind: TxKind::Call(caller),
+                gas_limit: 100_000,
+                gas_price: 0,
+                value: U256::ZERO,
+                data: Bytes::from(hex::decode("deadbeef01020304").unwrap()),
+                ..Default::default()
+            },
+            enveloped_tx: None,
+            deposit: DepositTransactionParts {
+                source_hash: B256::from([9u8; 32]),
+                mint: Some(0),
+                is_system_transaction: false,
+                eth_value: Some(eth_value),
+                eth_tx_value: Some(eth_value),
+            },
+        };
+
+        let block_env = BlockEnv {
+            number: U256::from(59294u64),
+            gas_limit: 30_000_000,
+            basefee: 1_000_000_000,
+            ..Default::default()
+        };
+        let l1_block_info = L1BlockInfo {
+            l2_block: Some(U256::from(59294u64)),
+            token_ratio: U256::from(3040u64),
+            ..Default::default()
+        };
+
+        let ctx = Context::op()
+            .with_db(InMemoryDB::default())
+            .with_chain(l1_block_info)
+            .with_block(block_env)
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ISTHMUS)
+            .with_tx(op_tx);
+        let mut evm = ctx.build_op();
+        let mut handler = OpHandler::<
+            _,
+            EVMError<_, crate::transaction::error::OpTransactionError>,
+            EthFrame<EthInterpreter>,
+        >::new();
+        let result = handler.run(&mut evm).expect("deposit must execute");
+
+        let gas = result.gas_used();
+        assert_ne!(
+            gas, 25_628,
+            "spurious BVM_ETH_MINT_GAS_COMPENSATION (+4500) must be gone"
+        );
+        assert_eq!(
+            gas, 21_320,
+            "deposit gasUsed must match op-geth EIP-7623 floor (hoodi-qa2 block 59294)"
+        );
+    }
+
+    #[test]
+    fn process_eth_deposit_all_slots_cold_after_mint_and_transfer() {
+        // Verify ALL storage slots touched by mint + transfer are cold:
+        // balance(caller), balance(to), totalSupply.
+        // This ensures mark_address_cold covers every slot, not just one.
+        let caller = Address::from([0x11; 20]);
+        let recipient = Address::from([0x22; 20]); // different from caller
+        let eth_value = 1_000_000_000_000_000u128;
+
+        let mut ctx = Context::op()
+            .with_db(InMemoryDB::default())
+            .modify_tx_chained(|tx| {
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Call(recipient);
+                tx.deposit.source_hash = B256::from([1u8; 32]);
+                tx.deposit.eth_value = Some(eth_value);
+                tx.deposit.eth_tx_value = Some(eth_value);
+            });
+
+        BvmEth::process_eth_deposit(&mut ctx, false).expect("deposit should succeed");
+
+        // Account must be cold
+        let acc = ctx
+            .journaled_state
+            .load_account(BvmEth::ADDRESS)
+            .expect("load BVM_ETH");
+        assert!(acc.is_cold, "BVM_ETH account must be cold");
+
+        // balance(caller) — warmed by mint_inner + transfer_inner
+        let slot_caller = BvmEth::get_balance_slot(caller);
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_caller)
+            .expect("sload balance(caller)");
+        assert!(loaded.is_cold, "balance(caller) must be cold");
+
+        // balance(recipient) — warmed by transfer_inner
+        let slot_recipient = BvmEth::get_balance_slot(recipient);
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_recipient)
+            .expect("sload balance(recipient)");
+        assert!(loaded.is_cold, "balance(recipient) must be cold");
+
+        // totalSupply — warmed by add_total_supply in mint_inner
+        let slot_supply = BvmEth::get_total_supply_slot();
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_supply)
+            .expect("sload totalSupply");
+        assert!(loaded.is_cold, "totalSupply must be cold");
+    }
+
+    #[test]
+    fn process_eth_deposit_mint_only_no_transfer() {
+        // When eth_tx_value is None, only mint_inner runs (no transfer_inner).
+        // Slots warmed: balance(caller) + totalSupply. Both must be cold after.
+        let caller = Address::from([0x33; 20]);
+        let recipient = Address::from([0x44; 20]);
+        let eth_value = 2_000_000_000_000_000u128;
+
+        let mut ctx = Context::op()
+            .with_db(InMemoryDB::default())
+            .modify_tx_chained(|tx| {
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Call(recipient);
+                tx.deposit.source_hash = B256::from([2u8; 32]);
+                tx.deposit.eth_value = Some(eth_value);
+                tx.deposit.eth_tx_value = None; // no transfer
+            });
+
+        BvmEth::process_eth_deposit(&mut ctx, false).expect("deposit should succeed");
+
+        let acc = ctx
+            .journaled_state
+            .load_account(BvmEth::ADDRESS)
+            .expect("load BVM_ETH");
+        assert!(acc.is_cold, "BVM_ETH account must be cold (mint-only)");
+
+        let slot_caller = BvmEth::get_balance_slot(caller);
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_caller)
+            .expect("sload balance(caller)");
+        assert!(loaded.is_cold, "balance(caller) must be cold (mint-only)");
+
+        let slot_supply = BvmEth::get_total_supply_slot();
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_supply)
+            .expect("sload totalSupply");
+        assert!(loaded.is_cold, "totalSupply must be cold (mint-only)");
+
+        // balance(recipient) should NOT have been loaded at all (no transfer)
+        // Accessing it now should also be cold (never touched by process_eth_deposit)
+        let slot_recipient = BvmEth::get_balance_slot(recipient);
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_recipient)
+            .expect("sload balance(recipient)");
+        assert!(
+            loaded.is_cold,
+            "balance(recipient) must be cold (never touched in mint-only)"
+        );
+    }
+
+    #[test]
+    fn process_eth_deposit_from_eq_to_transfer_skipped() {
+        // When from == to, transfer_inner returns early (no-op).
+        // Only mint_inner runs. Verify cold state is still correct.
+        let caller = Address::from([0x55; 20]);
+        let eth_value = 500_000_000_000_000u128;
+
+        let mut ctx = Context::op()
+            .with_db(InMemoryDB::default())
+            .modify_tx_chained(|tx| {
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Call(caller); // to == from → transfer_inner skips
+                tx.deposit.source_hash = B256::from([3u8; 32]);
+                tx.deposit.eth_value = Some(eth_value);
+                tx.deposit.eth_tx_value = Some(eth_value);
+            });
+
+        BvmEth::process_eth_deposit(&mut ctx, false).expect("deposit should succeed");
+
+        let acc = ctx
+            .journaled_state
+            .load_account(BvmEth::ADDRESS)
+            .expect("load BVM_ETH");
+        assert!(acc.is_cold, "BVM_ETH account must be cold (from==to)");
+
+        // balance(caller) — warmed by mint_inner only (transfer skipped)
+        let slot = BvmEth::get_balance_slot(caller);
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot)
+            .expect("sload balance(caller)");
+        assert!(loaded.is_cold, "balance(caller) must be cold (from==to)");
+
+        let slot_supply = BvmEth::get_total_supply_slot();
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_supply)
+            .expect("sload totalSupply");
+        assert!(loaded.is_cold, "totalSupply must be cold (from==to)");
+    }
+
+    #[test]
+    fn process_eth_deposit_no_eth_value_no_warming() {
+        // When neither eth_value nor eth_tx_value is set, process_eth_deposit
+        // returns early without loading BVM_ETH at all. No warming occurs.
+        let caller = Address::from([0x66; 20]);
+
+        let mut ctx = Context::op()
+            .with_db(InMemoryDB::default())
+            .modify_tx_chained(|tx| {
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Call(caller);
+                tx.deposit.source_hash = B256::from([4u8; 32]);
+                tx.deposit.eth_value = None;
+                tx.deposit.eth_tx_value = None;
+            });
+
+        BvmEth::process_eth_deposit(&mut ctx, false).expect("deposit should succeed");
+
+        // BVM_ETH account was never loaded, first access must be cold
+        let acc = ctx
+            .journaled_state
+            .load_account(BvmEth::ADDRESS)
+            .expect("load BVM_ETH");
+        assert!(
+            acc.is_cold,
+            "BVM_ETH must be cold when no eth_value/eth_tx_value"
+        );
+    }
+
+    #[test]
+    fn process_eth_deposit_state_changes_persist_after_cold_reset() {
+        // mark_address_cold must NOT undo the balance/totalSupply state changes.
+        // Only the warm/cold flags should be reset.
+        let caller = Address::from([0x77; 20]);
+        let recipient = Address::from([0x88; 20]);
+        let eth_value = 3_000_000_000_000_000u128; // 0.003 ETH
+
+        let mut ctx = Context::op()
+            .with_db(InMemoryDB::default())
+            .modify_tx_chained(|tx| {
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Call(recipient);
+                tx.deposit.source_hash = B256::from([5u8; 32]);
+                tx.deposit.eth_value = Some(eth_value);
+                tx.deposit.eth_tx_value = Some(eth_value);
+            });
+
+        BvmEth::process_eth_deposit(&mut ctx, false).expect("deposit should succeed");
+
+        // balance(caller) should have been minted (mint_inner) then debited (transfer_inner)
+        // mint: 0 + eth_value = eth_value, transfer: eth_value - eth_value = 0
+        let slot_caller = BvmEth::get_balance_slot(caller);
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_caller)
+            .expect("sload balance(caller)");
+        assert_eq!(
+            loaded.data,
+            U256::ZERO,
+            "balance(caller) should be 0 after mint+transfer of same amount"
+        );
+
+        // balance(recipient) should have received the transfer
+        let slot_recipient = BvmEth::get_balance_slot(recipient);
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_recipient)
+            .expect("sload balance(recipient)");
+        assert_eq!(
+            loaded.data,
+            U256::from(eth_value),
+            "balance(recipient) should equal eth_value after transfer"
+        );
+
+        // totalSupply should have increased by eth_value (from mint)
+        let slot_supply = BvmEth::get_total_supply_slot();
+        let loaded = ctx
+            .journaled_state
+            .sload(BvmEth::ADDRESS, slot_supply)
+            .expect("sload totalSupply");
+        assert_eq!(
+            loaded.data,
+            U256::from(eth_value),
+            "totalSupply should equal eth_value after mint"
+        );
+    }
+
     #[derive(Debug, Serialize, Deserialize)]
     struct BvmEthDepositTestCase {
         block_number: u64,

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -507,8 +507,13 @@ impl EvmStorageSlot {
     #[inline]
     pub fn mark_warm_with_transaction_id(&mut self, transaction_id: usize) -> bool {
         let is_cold = self.is_cold_transaction_id(transaction_id);
-        if is_cold {
-            // if slot is cold original value should be reset to present value.
+        // Re-baseline the EIP-2200 `original_value` ONLY when the slot genuinely belongs to a
+        // previous transaction (transaction_id mismatch). A slot that is merely flagged cold
+        // within the SAME transaction — e.g. an access-list reset for warm/cold parity such as
+        // the BVM_ETH deposit mint, or a reverted `StorageWarmed` entry — must keep its original
+        // baseline (the value at the start of THIS transaction). Using `is_cold` here (which also
+        // covers the same-tx cold flag) wrongly re-baselines those cases.
+        if self.transaction_id != transaction_id {
             self.original_value = self.present_value;
         }
         self.transaction_id = transaction_id;


### PR DESCRIPTION
## Summary

Ports the BVM_ETH deposit gas-parity fix to the `mantle-elysium` line (op-revm 19.0.0 / revm-19). On the current line (revm v2.2.x) the fix is op-revm-only (see the matching PR), but revm-19 needs **one additional core change** because its journal couples EIP-2929 cold/warm with the EIP-2200 `original_value` baseline.

Two commits:

### 1. `fix(state): re-baseline SSTORE original_value only across tx boundaries`

`EvmStorageSlot::mark_warm_with_transaction_id` reset `original_value = present_value` whenever the slot was *cold*. But "cold" (`is_cold_transaction_id`) also covers a slot flagged cold **within the same transaction** (an access-list reset, or a reverted `StorageWarmed` entry). Re-baselining in that case is wrong — the EIP-2200 `original` must stay the value at the start of the current transaction.

Restrict the re-baseline to genuine **cross-transaction** access (`transaction_id != self.transaction_id`):

```diff
-        if is_cold {
-            // if slot is cold original value should be reset to present value.
+        if self.transaction_id != transaction_id {
             self.original_value = self.present_value;
         }
```

Standard Ethereum execution never marks a slot cold mid-transaction, so this is **fully backward-compatible** (validated against the whole state + blockchain test suites, see below). It is required by the BVM_ETH fix below, which deliberately resets BVM_ETH to cold mid-tx for op-geth parity.

### 2. `fix(op-revm): reset BVM_ETH to cold after deposit mint to match op-geth`

Same as the v2.2.x fix: `JournalColdExt::mark_address_cold` resets BVM_ETH (account + touched slots) to cold after `process_eth_deposit`, so the subsequent EVM sees it cold like op-geth's `StateDB.SetState()` mint; the static `BVM_ETH_MINT_GAS_COMPENSATION` (4500) hack is removed. With commit 1, this no longer corrupts the SSTORE `original_value` baseline.

## Why the core change is needed on revm-19 (not on v2.2.x)

The BVM_ETH mint runs via the journal **before** the EVM. On revm-19, marking those pre-written slots cold made `mark_warm` re-baseline `original_value` to the post-mint value, turning the bridge's `transferFrom` write-back from a 0-cost dirty-restore (+refund) into a 2800-gas modify → reth diverged from op-geth by **+2800** on `L2StandardBridge` deposits (block 89718944: 143829 vs op-geth 141029). v2.2.x has no such re-baseline, so the op-revm-only fix is sufficient there.

## Validation (zero failures)

| Suite | Result |
|---|---|
| `cargo test -p op-revm` | 113 passed |
| core crates (state/context/interpreter/handler/revm) | 111 passed |
| execution-spec-tests **state_tests** (stable + develop) | All passed |
| legacy GeneralStateTests (Cancun + Constantinople) | All passed |
| **blockchain_tests** stable | **39161 passed, 0 failed** |
| **blockchain_tests** develop | **57488 passed, 0 failed** |

The ~97k blockchain tests exercise the multi-transaction cross-tx re-baseline path that commit 1 keeps; the state tests cover single-tx SSTORE/refund. Mantle-side: bridge deposit (89718944) = 141029 ✅, EOA+calldata deposit (hoodi 59294 reconstruction) = 21320 ✅.

## Notes

- Background / full root-cause: `docs/deposit-tx-gas-divergence-investigation.md` §9 in the consuming repo.
- Commit 1 touches shared core revm. It is a precise, test-validated hardening (`is_cold` → `transaction_id` mismatch); it could optionally be proposed to upstream revm, but standard execution never triggers the over-broad branch, so upstream is not affected either way.
