### PR TITLE
fix(op-revm): op-geth parity for deposit pre-call gates and the Isthmus precompile set

### DIFF
--- a/crates/ee-tests/src/op_revm_tests.rs
+++ b/crates/ee-tests/src/op_revm_tests.rs
@@ -242,6 +242,65 @@ fn test_halted_tx_call_bn254_pair_granite() {
 }
 
 #[test]
+fn test_tx_call_bn254_pair_isthmus_unrestricted() {
+    // [mantle] Mantle maps its entire pre-Limb era to OpSpecId::ISTHMUS, whose
+    // precompile set matches op-geth `PrecompiledContractsMantleSkadi`: the bn254
+    // pairing carries NO OP Stack input-size limit. We feed an input that is a
+    // valid multiple of the pair-element length but still larger than the Granite
+    // limit, so the ONLY thing that could reject it on length grounds is the OP
+    // Granite cap. Before the fix, Isthmus inherited that cap and bailed out with
+    // the "bn254 invalid pair length" halt; after the fix it goes down the
+    // standard (unrestricted) path. This is the e2e regression for rebuilding
+    // `isthmus()` on top of `fjord()` instead of `granite()`.
+    const SPEC_ID: OpSpecId = OpSpecId::ISTHMUS;
+
+    // Smallest multiple of PAIR_ELEMENT_LEN strictly greater than the Granite cap.
+    let oversized_len =
+        (GRANITE_MAX_INPUT_SIZE / bn254::PAIR_ELEMENT_LEN + 1) * bn254::PAIR_ELEMENT_LEN;
+    assert!(oversized_len > GRANITE_MAX_INPUT_SIZE);
+    assert!(oversized_len.is_multiple_of(bn254::PAIR_ELEMENT_LEN));
+    let input = Bytes::from(vec![1u8; oversized_len]);
+
+    // Use the per-tx gas cap as the limit: it clears the EIP-7623 calldata floor
+    // (so the tx is valid under Prague) yet is below the ~20M the 587-point
+    // pairing would need, so the unrestricted path runs out of precompile gas
+    // rather than fully executing. The point is only that it gets PAST the length
+    // gate that Granite would have rejected.
+    let ctx = Context::op()
+        .with_tx(
+            OpTransaction::builder()
+                .base(
+                    TxEnv::builder()
+                        .kind(TxKind::Call(bn254::pair::ADDRESS))
+                        .data(input)
+                        .gas_limit(eip7825::TX_GAS_LIMIT_CAP),
+                )
+                .build_fill(),
+        )
+        .with_cfg(CfgEnv::new_with_spec(SPEC_ID));
+
+    let mut evm = ctx.build_op();
+    let output = evm.replay().unwrap();
+
+    // The fix: Isthmus must NOT reject the oversized (but well-formed) input with
+    // the Granite-style OP input-size halt. Any other outcome (e.g. running out
+    // of precompile gas) is fine — it just means the OP cap is gone.
+    assert!(
+        !matches!(
+            output.result,
+            ExecutionResult::Halt {
+                reason: OpHaltReason::Base(HaltReason::PrecompileErrorWithContext(ref msg)),
+                ..
+            } if msg == "bn254 invalid pair length"
+        ),
+        "Isthmus bn254 pairing must not enforce the OP input-size limit (matches op-geth MantleSkadi), got: {:?}",
+        output.result
+    );
+
+    compare_or_save_op_testdata("test_tx_call_bn254_pair_isthmus_unrestricted.json", &output);
+}
+
+#[test]
 fn test_halted_tx_call_bls12_381_g1_add_out_of_gas() {
     let ctx = Context::op()
         .with_tx(

--- a/crates/ee-tests/tests/op_revm_testdata/test_tx_call_bn254_pair_isthmus_unrestricted.json
+++ b/crates/ee-tests/tests/op_revm_testdata/test_tx_call_bn254_pair_isthmus_unrestricted.json
@@ -1,0 +1,155 @@
+{
+  "result": {
+    "Halt": {
+      "gas": {
+        "floor_gas": 4529160,
+        "gas_refunded": 0,
+        "gas_spent": 16777216,
+        "state_gas_spent": 0
+      },
+      "logs": [],
+      "reason": {
+        "Base": {
+          "OutOfGas": "Precompile"
+        }
+      }
+    }
+  },
+  "state": {
+    "0x0000000000000000000000000000000000000000": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 1
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x0000000000000000000000000000000000000008": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    },
+    "0x4200000000000000000000000000000000000019": {
+      "info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "original_info": {
+        "balance": "0x0",
+        "code": {
+          "LegacyAnalyzed": {
+            "bytecode": "0x00",
+            "jump_table": {
+              "bits": 0,
+              "data": [],
+              "head": {
+                "index": 0,
+                "width": 8
+              },
+              "order": "bitvec::order::Lsb0"
+            },
+            "original_len": 0
+          }
+        },
+        "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "nonce": 0
+      },
+      "status": "Touched | LoadedAsNotExisting",
+      "storage": {},
+      "transaction_id": 0
+    }
+  }
+}

--- a/crates/op-revm/src/handler.rs
+++ b/crates/op-revm/src/handler.rs
@@ -227,6 +227,29 @@ where
                 caller.bump_nonce();
             }
 
+            // Pre-call gates that op-geth applies inside innerExecute() and routes to the
+            // mint-only failed-deposit path (RevertToSnapshot + gasUsed=GasLimit). op-revm
+            // skips env validation for deposits ("pre-verified on L1"), so without these the
+            // condition leaks into the EVM frame and takes the wrong (success/keep-transfer)
+            // route, diverging from op-geth. See state_transition.go innerExecute().
+
+            // (#5) EIP-3860 init code size limit for CREATE deposits (state_transition.go L786).
+            if tx.kind().is_create()
+                && spec.into_eth_spec().is_enabled_in(SpecId::SHANGHAI)
+                && tx.input().len() > cfg.max_initcode_size()
+            {
+                return Err(InvalidTransaction::CreateInitCodeSizeLimit.into());
+            }
+            // (#4) Native (MNT) value transfer must be affordable (CanTransfer, L781), checked
+            // against the post-mint balance, mirroring op-geth (mint is applied pre-snapshot).
+            if !cfg.is_balance_check_disabled() && *caller.balance() < tx.value() {
+                return Err(InvalidTransaction::LackOfFundForMaxFee {
+                    fee: Box::new(tx.value()),
+                    balance: Box::new(*caller.balance()),
+                }
+                .into());
+            }
+
             return Ok(());
         }
 
@@ -3948,5 +3971,146 @@ mod tests {
 
         // FailedDeposit halt + Mint + Transfer(caller -> created) in logs AND state.
         assert_failed_deposit_mint_and_transfer(&out.result, to_balance, created, amount);
+    }
+
+    /// (#4) Native (MNT) value transfer larger than the caller can afford after the mint.
+    /// op-geth gates this with CanTransfer inside innerExecute() -> RevertToSnapshot ->
+    /// mint-only (1 BVM_ETH Mint log, transfer + native value rolled back, native mint kept).
+    /// Without the pre-call CanTransfer gate revm would route this through the EVM frame and
+    /// keep the BVM_ETH transfer, diverging from op-geth.
+    #[test]
+    fn test_failed_deposit_native_value_too_large_keeps_eth_mint_only() {
+        use revm::{bytecode::Bytecode, primitives::TxKind, ExecuteEvm};
+
+        let caller = Address::from([0x11; 20]);
+        let target = Address::from([0x42; 20]);
+        let native_mint = 1_000_000_000_000_000u128; // 1e15
+        let native_value = 2_000_000_000_000_000u128; // 2e15 > mint, caller can't afford
+        let eth_amount = 3_000_000_000_000_000u128; // BVM_ETH mint == transfer (would succeed)
+
+        let mut db = InMemoryDB::default();
+        // caller starts at ZERO native balance, so its only MNT is the mint (1e15) < value (2e15).
+        db.insert_account_info(caller, AccountInfo::default());
+        let tcode = Bytecode::new_raw(Bytes::from(std::vec![0x00u8])); // STOP (would succeed if reached)
+        let code_hash = tcode.hash_slow();
+        db.insert_account_info(
+            target,
+            AccountInfo {
+                code_hash,
+                code: Some(tcode),
+                ..Default::default()
+            },
+        );
+        let ctx = Context::op()
+            .with_db(db)
+            .modify_tx_chained(|tx| {
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Call(target);
+                tx.base.value = U256::from(native_value);
+                tx.base.gas_limit = 200_000;
+                tx.deposit.source_hash = B256::from([1u8; 32]);
+                tx.deposit.mint = Some(native_mint);
+                tx.deposit.eth_value = Some(eth_amount);
+                tx.deposit.eth_tx_value = Some(eth_amount);
+            })
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::REGOLITH);
+        let mut evm = ctx.build_op();
+        let out = evm.replay().unwrap();
+
+        let logs = out.result.logs();
+        let target_eth = out
+            .state
+            .get(&BvmEth::ADDRESS)
+            .and_then(|a| a.storage.get(&BvmEth::get_balance_slot(target)))
+            .map(|s| s.present_value)
+            .unwrap_or_default();
+        let caller_native = out
+            .state
+            .get(&caller)
+            .map(|a| a.info.balance)
+            .unwrap_or_default();
+        let target_native = out
+            .state
+            .get(&target)
+            .map(|a| a.info.balance)
+            .unwrap_or_default();
+
+        // op-geth expectation: exactly ONE log = BVM_ETH Mint (transfer rolled back).
+        assert_eq!(
+            logs.len(),
+            1,
+            "expected only the BVM_ETH Mint log; got {logs:?}"
+        );
+        assert_eq!(
+            logs[0].topics()[0],
+            BvmEth::MINT_SELECTOR,
+            "the one log must be Mint"
+        );
+        // ETH transfer rolled back -> target holds no BVM_ETH.
+        assert_eq!(target_eth, U256::ZERO, "BVM_ETH transfer must be rolled back");
+        // Native MNT value transfer failed/rolled back -> target got no MNT.
+        assert_eq!(target_native, U256::ZERO, "native MNT value must not transfer");
+        // Native MNT mint persists -> caller keeps exactly the mint.
+        assert_eq!(
+            caller_native,
+            U256::from(native_mint),
+            "native MNT mint must persist"
+        );
+    }
+
+    /// (#5) CREATE deposit whose init code exceeds EIP-3860 MaxInitCodeSize (49152 bytes),
+    /// with BVM_ETH mint+transfer set and the native value affordable (so the ONLY failure
+    /// is the init-code-size limit). op-geth treats this as a pre-call Go error
+    /// (ErrMaxInitCodeSizeExceeded) -> RevertToSnapshot -> mint-only (1 Mint log, transfer
+    /// rolled back). Without the pre-call EIP-3860 gate revm keeps the transfer.
+    #[test]
+    fn test_failed_create_deposit_initcode_too_large_keeps_eth_mint_only() {
+        use revm::{primitives::TxKind, ExecuteEvm};
+
+        let caller = Address::from([0x11; 20]);
+        let amount = 1_000_000_000_000_000u128; // BVM_ETH mint == transfer
+        let created = caller.create(0);
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            caller,
+            AccountInfo {
+                balance: U256::from(10_000_000_000_000_000_000u128), // plenty (value affordable)
+                ..Default::default()
+            },
+        );
+        // 49153 bytes > MaxInitCodeSize (49152). Zero bytes (cheap calldata gas).
+        let init_code = std::vec![0x00u8; 49153];
+        let ctx = Context::op()
+            .with_db(db)
+            .modify_tx_chained(|tx| {
+                tx.base.caller = caller;
+                tx.base.kind = TxKind::Create;
+                tx.base.data = Bytes::from(init_code);
+                tx.base.gas_limit = 5_000_000; // covers intrinsic+calldata, isolates size limit
+                tx.deposit.source_hash = B256::from([1u8; 32]);
+                tx.deposit.eth_value = Some(amount);
+                tx.deposit.eth_tx_value = Some(amount);
+            })
+            // ARSIA -> SHANGHAI+ enabled, so EIP-3860 init code size limit is active.
+            .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::ARSIA);
+        let mut evm = ctx.build_op();
+        let out = evm.replay().unwrap();
+
+        let logs = out.result.logs();
+        let created_eth = out
+            .state
+            .get(&BvmEth::ADDRESS)
+            .and_then(|a| a.storage.get(&BvmEth::get_balance_slot(created)))
+            .map(|s| s.present_value)
+            .unwrap_or_default();
+        // op-geth expectation: mint-only (1 Mint log, transfer rolled back).
+        assert_eq!(logs.len(), 1, "op-geth keeps only Mint; got {} logs", logs.len());
+        assert_eq!(
+            logs[0].topics()[0],
+            BvmEth::MINT_SELECTOR,
+            "the one log must be Mint"
+        );
+        assert_eq!(created_eth, U256::ZERO, "BVM_ETH transfer must be rolled back");
     }
 }

--- a/crates/op-revm/src/precompiles.rs
+++ b/crates/op-revm/src/precompiles.rs
@@ -79,18 +79,24 @@ pub fn granite() -> &'static Precompiles {
 }
 
 /// Returns precompiles for isthmus spec.
+///
+/// [mantle] Mantle maps its entire pre-Limb era (Skadi and genesis) to
+/// `OpSpecId::ISTHMUS`. op-geth's `PrecompiledContractsMantleSkadi` is the
+/// standard Prague precompile set plus secp256r1 `p256verify`, using the
+/// standard EIP-2537 BLS12-381 precompiles and the standard Istanbul bn254
+/// pairing — none of which carry OP Stack input-size limits. We therefore build
+/// the Isthmus set from `fjord()` (Cancun + p256verify, with the unrestricted
+/// Istanbul bn254 pairing) and the unrestricted Prague BLS12-381 precompiles,
+/// instead of inheriting the input-size limits added by `granite()` and the
+/// upstream OP Isthmus BLS modifications. This keeps op-revm consensus-consistent
+/// with Mantle op-geth for the pre-Limb era.
 pub fn isthmus() -> &'static Precompiles {
     static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
     INSTANCE.get_or_init(|| {
-        let mut precompiles = granite().clone();
-        // Prague bls12 precompiles
+        let mut precompiles = fjord().clone();
+        // Standard (unrestricted) Prague bls12 precompiles, matching op-geth
+        // PrecompiledContractsMantleSkadi.
         precompiles.extend(precompile::bls12_381::precompiles());
-        // Isthmus bls12 precompile modifications
-        precompiles.extend([
-            bls12_381::ISTHMUS_G1_MSM,
-            bls12_381::ISTHMUS_G2_MSM,
-            bls12_381::ISTHMUS_PAIRING,
-        ]);
         precompiles
     })
 }
@@ -487,6 +493,57 @@ mod tests {
             .unwrap();
         assert!(
             matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Other(msg)) if msg.contains("input length too long"))
+        );
+    }
+
+    /// Mantle maps the whole pre-Limb era (including Skadi and genesis) to
+    /// `OpSpecId::ISTHMUS`. op-geth's `PrecompiledContractsMantleSkadi` uses the
+    /// standard EIP-2537 BLS12-381 precompiles and the standard Istanbul bn254
+    /// pairing, i.e. WITHOUT any OP Stack input-size limits. Therefore the
+    /// Isthmus precompile set in op-revm must not reject oversized bn254/BLS
+    /// inputs purely on length grounds, to stay consensus-consistent with
+    /// Mantle op-geth.
+    #[test]
+    fn test_isthmus_bn254_and_bls_unrestricted_for_mantle() {
+        let precompiles = OpPrecompiles::new_with_spec(OpSpecId::ISTHMUS);
+        let precompiles = precompiles.precompiles();
+
+        // bn254 pairing (0x08): 587 elements = 112704 bytes, a valid multiple of
+        // PAIR_ELEMENT_LEN(192) exceeding GRANITE_MAX_INPUT_SIZE(112687).
+        let bn254_pairing = precompiles.get(&bn254::pair::ADDRESS).unwrap();
+        let input = vec![0u8; 587 * bn254::PAIR_ELEMENT_LEN];
+        assert!(input.len() > bn254_pair::GRANITE_MAX_INPUT_SIZE);
+        let res = bn254_pairing.execute(&input, u64::MAX, 0).unwrap();
+        assert!(
+            !matches!(res.status, PrecompileStatus::Halt(PrecompileHalt::Bn254PairLength)),
+            "Isthmus bn254 pairing must not impose an OP input-size limit (op-geth MantleSkadi has none)"
+        );
+
+        // BLS12-381 g1 msm (0x0c)
+        let g1 = precompiles.get(&bls12_381_const::G1_MSM_ADDRESS).unwrap();
+        let input = vec![0u8; ISTHMUS_G1_MSM_MAX_INPUT_SIZE + 160];
+        let res = g1.execute(&input, u64::MAX, 0).unwrap();
+        assert!(
+            !matches!(&res.status, PrecompileStatus::Halt(PrecompileHalt::Other(m)) if m.contains("input length too long")),
+            "Isthmus BLS g1 msm must not impose an OP input-size limit"
+        );
+
+        // BLS12-381 g2 msm (0x0e)
+        let g2 = precompiles.get(&bls12_381_const::G2_MSM_ADDRESS).unwrap();
+        let input = vec![0u8; ISTHMUS_G2_MSM_MAX_INPUT_SIZE + 288];
+        let res = g2.execute(&input, u64::MAX, 0).unwrap();
+        assert!(
+            !matches!(&res.status, PrecompileStatus::Halt(PrecompileHalt::Other(m)) if m.contains("input length too long")),
+            "Isthmus BLS g2 msm must not impose an OP input-size limit"
+        );
+
+        // BLS12-381 pairing (0x0f)
+        let pairing = precompiles.get(&bls12_381_const::PAIRING_ADDRESS).unwrap();
+        let input = vec![0u8; ISTHMUS_PAIRING_MAX_INPUT_SIZE + 384];
+        let res = pairing.execute(&input, u64::MAX, 0).unwrap();
+        assert!(
+            !matches!(&res.status, PrecompileStatus::Halt(PrecompileHalt::Other(m)) if m.contains("input length too long")),
+            "Isthmus BLS pairing must not impose an OP input-size limit"
         );
     }
 


### PR DESCRIPTION
## Summary

Two independent op-geth parity fixes for the Elysium (v107) line, plus an e2e regression test. Both address places where op-revm's behaviour diverges from Mantle op-geth.

### 1. Deposit pre-call gates — `crates/op-revm/src/handler.rs`

op-geth runs all pre-call checks inside `innerExecute()` and, on a deposit, routes any failure to the mint-only path (`RevertToSnapshot` + `gasUsed = GasLimit`), keeping only the BVM_ETH `Mint` log. op-revm skips env validation for deposits, so two pre-call conditions leaked into the EVM frame and took the wrong route:

- native (MNT) value transfer the caller cannot cover after the mint (`CanTransfer`, `state_transition.go` L781)
- CREATE deposit whose init code exceeds EIP-3860 `MAX_INITCODE_SIZE` (`state_transition.go` L786)

Both are now gated in `validate_against_state_and_deduct_caller`'s deposit branch, returning a tx-level error → `catch_error` → mint-only, matching op-geth.

This ports the equivalent arsia-line gates to elysium.

### 2. Isthmus precompile input-size limits — `crates/op-revm/src/precompiles.rs`

Mantle maps its entire pre-Limb era (Skadi and genesis) to `OpSpecId::ISTHMUS` — see mantle-v2 alloy-op-evm `spec_by_timestamp_after_bedrock` and kona `mantle_spec_id`: anything below Limb maps to `ISTHMUS`.

op-geth's pre-Limb set `PrecompiledContractsMantleSkadi` is the standard Prague precompile set plus secp256r1 `p256verify`: standard Istanbul bn254 pairing, standard EIP-2537 BLS12-381, **no OP Stack input-size limits**.

op-revm's `isthmus()` however inherited `granite()`'s bn254 pairing cap (`GRANITE_MAX_INPUT_SIZE = 112687`) plus the upstream OP Isthmus BLS12-381 caps (G1 MSM / G2 MSM / pairing), so it rejected oversized-but-valid inputs that Mantle op-geth accepts.

`isthmus()` is now built from `fjord()` (Cancun + `p256verify`, unrestricted Istanbul bn254 pairing) plus the unrestricted Prague BLS12-381 precompiles, matching `PrecompiledContractsMantleSkadi` exactly.

- `jovian()` is unaffected: it removes the variable-input precompiles by address and re-adds its own Jovian-limited versions.
- OSAKA/ARSIA (Limb and after) were already correct.

### 3. e2e regression — `crates/ee-tests`

Mirrors the existing bn254 fjord/granite tx-level tests with an Isthmus case: feeds the bn254 pairing precompile an input that is a valid multiple of the pair-element length but larger than the Granite cap, so length is the only thing that could reject it. Asserts the call is *not* halted with the Granite-style `bn254 invalid pair length` error.

Verified RED on the pre-fix granite-based `isthmus()` and GREEN after the fix.

## Test plan

```
cargo test -p op-revm --lib
  → 125 passed; 0 failed
    handler::tests::test_failed_deposit_native_value_too_large_keeps_eth_mint_only ... ok
    handler::tests::test_failed_create_deposit_initcode_too_large_keeps_eth_mint_only ... ok
    precompiles::tests::test_isthmus_bn254_and_bls_unrestricted_for_mantle ... ok

cargo test -p revm-ee-tests
  → 76 passed; 0 failed
    op_revm_tests::test_tx_call_bn254_pair_isthmus_unrestricted ... ok
```

Branch is cherry-picked cleanly onto `mantle-elysium` (no conflicts).
